### PR TITLE
New version: MCTS v0.4.1

### DIFF
--- a/M/MCTS/Deps.toml
+++ b/M/MCTS/Deps.toml
@@ -8,3 +8,6 @@ POMDPSimulators = "e0d0a172-29c6-5d4e-96d0-f262df5d01fd"
 POMDPs = "a93abf59-7444-517b-a68a-c42f96afdd7d"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+["0.4.1-0"]
+Registrator = "4418983a-e44d-11e8-3aec-9789530b3b3e"

--- a/M/MCTS/Versions.toml
+++ b/M/MCTS/Versions.toml
@@ -9,3 +9,6 @@ git-tree-sha1 = "7693e6f90c0a6e9312c6afcede39453efc694eb4"
 
 ["0.4.0"]
 git-tree-sha1 = "7b3376240757ca3b52236bf79751469db78b1bb7"
+
+["0.4.1"]
+git-tree-sha1 = "3a9b53be9de78f92e0e1612b98977b91d9c39cc4"


### PR DESCRIPTION
UUID: e12ccd36-dcad-5f33-8774-9175229e7b33
Repo: https://github.com/JuliaPOMDP/MCTS.jl.git
Tree: 3a9b53be9de78f92e0e1612b98977b91d9c39cc4

Registrator tree SHA: 29a8496c5a7411ca37876fd237ef8a4a6f938ee0