### PR TITLE
New version: MCTS v0.4.2

### DIFF
--- a/M/MCTS/Versions.toml
+++ b/M/MCTS/Versions.toml
@@ -12,3 +12,6 @@ git-tree-sha1 = "7b3376240757ca3b52236bf79751469db78b1bb7"
 
 ["0.4.1"]
 git-tree-sha1 = "3a9b53be9de78f92e0e1612b98977b91d9c39cc4"
+
+["0.4.2"]
+git-tree-sha1 = "1b8da8dd34ff2856d18c94e3937a07e78a0e46df"


### PR DESCRIPTION
UUID: e12ccd36-dcad-5f33-8774-9175229e7b33
Repo: https://github.com/JuliaPOMDP/MCTS.jl.git
Tree: 1b8da8dd34ff2856d18c94e3937a07e78a0e46df

Registrator tree SHA: unknown