### PR TITLE
New version: MCVI v0.3.1

### DIFF
--- a/M/MCVI/Compat.toml
+++ b/M/MCVI/Compat.toml
@@ -5,5 +5,13 @@ ParticleFilters = "*"
 julia = "*"
 
 ["0.3-0"]
-POMDPs = "0.7.3-0.8"
 julia = "1"
+
+["0.3.0"]
+POMDPs = "0.7.3-0.8"
+
+["0.3.1-0"]
+JSON = "0.21"
+POMDPLinter = "0.1"
+POMDPs = "0.9"
+ParticleFilters = "0.5"

--- a/M/MCVI/Deps.toml
+++ b/M/MCVI/Deps.toml
@@ -7,3 +7,6 @@ ParticleFilters = "c8b314e2-9260-5cf8-ae76-3be7461ca6d0"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+["0.3.1-0"]
+POMDPLinter = "f3bd98c0-eb40-45e2-9eb1-f2763262d755"

--- a/M/MCVI/Versions.toml
+++ b/M/MCVI/Versions.toml
@@ -3,3 +3,6 @@ git-tree-sha1 = "a0223448cee561e464cdfc87ab5f9b5fb9406056"
 
 ["0.3.0"]
 git-tree-sha1 = "6076c2af337558750cbb1309ab5ec587442381ea"
+
+["0.3.1"]
+git-tree-sha1 = "09b2eb295330bafee4ada9130eca297ab2a5401a"


### PR DESCRIPTION
UUID: 30d33687-f7ed-5b0d-8b26-3dc9b7abd572
Repo: https://github.com/JuliaPOMDP/MCVI.jl.git
Tree: 09b2eb295330bafee4ada9130eca297ab2a5401a

Registrator tree SHA: ea27832a31084895842c77e4f78f5beea9677abd